### PR TITLE
adds bibframe dissertation

### DIFF
--- a/lib/tufts/curation/schema/descriptive.rb
+++ b/lib/tufts/curation/schema/descriptive.rb
@@ -16,6 +16,7 @@ module Tufts
       #
       # @see ActiveFedora::Base
       # @see Hyrax::WorkBehavior
+      # rubocop:disable Metrics/ModuleLength
       module Descriptive
         extend ActiveSupport::Concern
 
@@ -142,6 +143,10 @@ module Tufts
           end
 
           property :oclc, predicate: ::Tufts::Vocab::Tufts.oclc do |index|
+            index.as :stored_searchable
+          end
+
+          property :dissertation_type, predicate: ::Tufts::Curation::Vocab::Bibframe.dissertation do |index|
             index.as :stored_searchable
           end
         end

--- a/lib/tufts/curation/tufts_model.rb
+++ b/lib/tufts/curation/tufts_model.rb
@@ -5,6 +5,7 @@ require 'models/concerns/hyrax/core_metadata'
 require 'models/concerns/hyrax/basic_metadata'
 
 require 'tufts/curation/vocab/tufts'
+require 'tufts/curation/vocab/bibframe'
 require 'tufts/curation/schema/administrative'
 require 'tufts/curation/schema/descriptive'
 require 'tufts/curation/schema/ordered'

--- a/lib/tufts/curation/vocab/bibframe.rb
+++ b/lib/tufts/curation/vocab/bibframe.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rdf'
+
+module Tufts
+  module Curation
+    module Vocab
+      class Bibframe < RDF::Vocabulary("http://id.loc.gov/ontologies/bibframe/")
+        term :dissertation
+      end
+    end
+  end
+end


### PR DESCRIPTION
hyrax needs rdf-vocab < 3.1.5 and dissertation isn't added till 3.1.10
this works around that by adding a supplamental bibframe class in the
vocab until we can get to hyrax 3.4 and move on to the supported
bibframe predicate