### PR TITLE
Redefines transcription relationship

### DIFF
--- a/lib/tufts/curation/schema/transcription.rb
+++ b/lib/tufts/curation/schema/transcription.rb
@@ -8,7 +8,7 @@ module Tufts
 
         included do
           belongs_to :transcript,
-                     predicate: ::RDF::Vocab::EBUCore.description,
+                     predicate: ::Tufts::Vocab::Tufts.transcription_of,
                      class_name: 'ActiveFedora::Base'
         end
       end

--- a/lib/tufts/curation/vocab/tufts.rb
+++ b/lib/tufts/curation/vocab/tufts.rb
@@ -40,6 +40,7 @@ module Tufts
         term :geog_name
         term :aspace_cuid
         term :oclc
+        term :transcription_of
       end
     end
   end


### PR DESCRIPTION
https://tuftswork.atlassian.net/browse/TDLR-2449

@rawOrlando this looks like it would resolve the transcription id in the description field, we'd want to:

- cut a versioned release of `tufts-curation` 
- update tdl and mira to use the new release.
- `update_index` items with a transcription

EBUCore.description was IMO maybe not the best choice anyway.