### PR TITLE
adds transcription schema to Generic Objects

### DIFF
--- a/lib/tufts/curation/generic_object.rb
+++ b/lib/tufts/curation/generic_object.rb
@@ -4,6 +4,8 @@ module Tufts
   module Curation
     ##
     # A GenericObject work type
-    class GenericObject < TuftsModel; end
+    class GenericObject < TuftsModel
+      include Tufts::Curation::Schema::Transcription
+    end
   end
 end


### PR DESCRIPTION
Generic Objects need access to the transcription schema to support Video with Transcripts fully in MIRA and TDL.
In support of TDLR-2509