### PR TITLE
changes run order of bundle install and rubygems setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,14 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler: "2.1.4"
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler-cache: false # runs 'bundle install' and caches installed gems automatically
     - name: Update rubygems
       run: |
         gem update --system 3.3.27
         gem install bundler:2.1.4
+    - name: bundle install
+      run: |
+        bundle install
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
bundle install was running before rubygems was upgraded causing builds to fail the past 2 months, this makes a changes to bring that into a predictable order.