### PR TITLE
removes call to method deleted in previous PR

### DIFF
--- a/lib/tufts/curation/file_set_indexer.rb
+++ b/lib/tufts/curation/file_set_indexer.rb
@@ -34,8 +34,6 @@ module Tufts
           if object.mime_type == "text/html"
             results = {}
 
-            find_indexable_fields(results)
-            # puts "#{results}"
             results.each do |field_name, field_values|
               # puts("  #{field_name}")
               if solr_doc["#{field_name}_tesim"].nil?


### PR DESCRIPTION
A method was deleted from the file_set indexer during the EAD removal but it is still in the indexer, need to remove, cut a new release and update MIRA.