### PR TITLE
Indexing identifier

### DIFF
--- a/lib/tufts/curation/indexer.rb
+++ b/lib/tufts/curation/indexer.rb
@@ -37,6 +37,10 @@ module Tufts
 
       def generate_solr_document
         super.tap do |solr_doc|
+          # record the indexing app name so we know who indexed this object
+          identifier = Tufts::Curation::IndexerIdentifier.new
+          solr_doc['indexing_app_tesim'] = identifier.identify
+
           solr_doc['pub_date_facet_isim'] = date_facet
           index_sort_fields solr_doc
           create_facets solr_doc

--- a/lib/tufts/curation/indexing_identifier.rb
+++ b/lib/tufts/curation/indexing_identifier.rb
@@ -1,0 +1,21 @@
+module Tufts
+  module Curation
+    class IndexerIdentifier
+      # Allow for global configuration
+      class << self
+        attr_accessor :configured_app_name
+      end
+
+      attr_accessor :app_name
+
+      def initialize(app_name = nil)
+        # Use the provided name, or fall back to the configured name, or the default
+        @app_name = app_name || self.class.configured_app_name || 'default_app'
+      end
+
+      def identify
+        @app_name
+      end
+    end
+  end
+end


### PR DESCRIPTION
We're having an issue with applications (MIRA, TDL, Trove) writing to a common index and can't track down who is causing the issue.  This PR allows us to configure the rails apps so they'll report themselves in the index as the writer.